### PR TITLE
consolidate extension methods

### DIFF
--- a/DragonFruit.Common.Data.Html.Tests/ApiClientSerializerTests.cs
+++ b/DragonFruit.Common.Data.Html.Tests/ApiClientSerializerTests.cs
@@ -16,7 +16,7 @@ namespace DragonFruit.Common.Data.Html.Tests
         public void PerformApiDeserializationTest()
         {
             var htmlDocument = _serializerClient.Perform<HtmlDocument>(new HtmlPageRequest());
-            var title = htmlDocument.DocumentNode.GetValueFromXPath("/html/body/div/h1[1]/a");
+            var title = htmlDocument.DocumentNode.GetValue("/html/body/div/h1[1]/a");
 
             Assert.AreEqual(title, "Certification");
         }

--- a/DragonFruit.Common.Data.Html.Tests/HtmlClientExtensionTests.cs
+++ b/DragonFruit.Common.Data.Html.Tests/HtmlClientExtensionTests.cs
@@ -7,12 +7,12 @@ namespace DragonFruit.Common.Data.Html.Tests
     public class HtmlClientExtensionTests
     {
         private readonly ApiClient _basicClient = new ApiClient();
-        
+
         [Test]
         public void PerformHtmlExtensionTest()
         {
             var htmlDocument = _basicClient.PerformHtml(new HtmlPageRequest());
-            var title = htmlDocument.DocumentNode.GetValueFromXPath("/html/body/div/h1[1]/a");
+            var title = htmlDocument.DocumentNode.GetValue("/html/body/div/h1[1]/a");
 
             Assert.AreEqual(title, "Certification");
         }

--- a/DragonFruit.Common.Data.Html/HtmlClientExtensions.cs
+++ b/DragonFruit.Common.Data.Html/HtmlClientExtensions.cs
@@ -22,20 +22,7 @@ namespace DragonFruit.Common.Data.Html
         /// <summary>
         /// Extracts a value from the <see cref="HtmlNode"/> based on its XPath and attribute name
         /// </summary>
-        public static string GetValueFromXPath(this HtmlNode node, string xpath = default, string attribute = default)
-        {
-            return node.GetValue(xpath, attribute, true);
-        }
-
-        /// <summary>
-        /// Extracts a value (or returns a default value) from the <see cref="HtmlNode"/> based on its XPath and attribute name
-        /// </summary>
-        public static string GetValueOrDefaultFromXPath(this HtmlNode node, string xpath = default, string attribute = default)
-        {
-            return node.GetValue(xpath, attribute, false);
-        }
-
-        private static string GetValue(this HtmlNode node, string xpath, string attribute, bool throwOnNotFound)
+        public static string GetValueFromXPath(this HtmlNode node, string xpath = default, string attribute = default, bool throwOnNotFound = false)
         {
             var subNode = string.IsNullOrEmpty(xpath) ? node : node.SelectSingleNode(xpath);
             var useInnerText = string.IsNullOrEmpty(attribute);

--- a/DragonFruit.Common.Data.Html/HtmlClientExtensions.cs
+++ b/DragonFruit.Common.Data.Html/HtmlClientExtensions.cs
@@ -22,25 +22,35 @@ namespace DragonFruit.Common.Data.Html
         /// <summary>
         /// Extracts a value from the <see cref="HtmlNode"/> based on its XPath and attribute name
         /// </summary>
-        public static string GetValueFromXPath(this HtmlNode node, string xpath, string attribute)
+        public static string GetValueFromXPath(this HtmlNode node, string xpath = default, string attribute = default)
         {
-            return node.SelectSingleNode(xpath).Attributes.Single(x => x.Name.Equals(attribute, StringComparison.OrdinalIgnoreCase)).Value;
+            return node.GetValue(xpath, attribute, true);
         }
 
         /// <summary>
         /// Extracts a value (or returns a default value) from the <see cref="HtmlNode"/> based on its XPath and attribute name
         /// </summary>
-        public static string GetValueOrDefaultFromXPath(this HtmlNode node, string xpath, string attribute)
+        public static string GetValueOrDefaultFromXPath(this HtmlNode node, string xpath = default, string attribute = default)
         {
-            return node.SelectSingleNode(xpath).Attributes.SingleOrDefault(x => x.Name.Equals(attribute, StringComparison.OrdinalIgnoreCase))?.Value;
+            return node.GetValue(xpath, attribute, false);
         }
 
-        /// <summary>
-        /// Extracts the inner text/html from a XPath against the <see cref="HtmlNode"/> provided
-        /// </summary>
-        public static string GetValueFromXPath(this HtmlNode node, string xpath)
+        private static string GetValue(this HtmlNode node, string xpath, string attribute, bool throwOnNotFound)
         {
-            return node.SelectSingleNode(xpath).InnerText;
+            var subNode = string.IsNullOrEmpty(xpath) ? node : node.SelectSingleNode(xpath);
+            var useInnerText = string.IsNullOrEmpty(attribute);
+
+            switch (useInnerText)
+            {
+                case false when throwOnNotFound:
+                    return subNode.Attributes.Single(x => x.Name.Equals(attribute, StringComparison.OrdinalIgnoreCase)).Value;
+
+                case false:
+                    return subNode.Attributes.SingleOrDefault(x => x.Name.Equals(attribute, StringComparison.OrdinalIgnoreCase))?.Value;
+
+                case true:
+                    return subNode.InnerText;
+            }
         }
     }
 }

--- a/DragonFruit.Common.Data.Html/HtmlClientExtensions.cs
+++ b/DragonFruit.Common.Data.Html/HtmlClientExtensions.cs
@@ -22,7 +22,7 @@ namespace DragonFruit.Common.Data.Html
         /// <summary>
         /// Extracts a value from the <see cref="HtmlNode"/> based on its XPath and attribute name
         /// </summary>
-        public static string GetValueFromXPath(this HtmlNode node, string xpath = default, string attribute = default, bool throwOnNotFound = false)
+        public static string GetValue(this HtmlNode node, string xpath = default, string attribute = default, bool throwOnNotFound = false)
         {
             var subNode = string.IsNullOrEmpty(xpath) ? node : node.SelectSingleNode(xpath);
             var useInnerText = string.IsNullOrEmpty(attribute);


### PR DESCRIPTION
combines the getfromxpath methods into a single version with overloads. also allows the extraction of an attribute on the node itself.